### PR TITLE
Fix reloc type in the absence of reloc hint

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -9514,7 +9514,7 @@ BYTE*               emitter::emitOutputRI(BYTE* dst, instrDesc* id)
 #ifdef RELOC_SUPPORT
         if (id->idIsCnsReloc())
         {
-            emitRecordRelocation((void*)(dst - (unsigned)EA_SIZE(size)), (void*)(size_t)val, IMAGE_REL_BASED_HIGHLOW);
+            emitRecordRelocation((void*)(dst - (unsigned)EA_SIZE(size)), (void*)(size_t)val, IMAGE_REL_BASED_MOFFSET);
         }
 #endif
 


### PR DESCRIPTION
When Reloc hint is no hint, JIT yields the wrong reloc type. mov eax, offset should yield DIR64 (MOFFSET for amd64) not HIGHLOW (MOFFSET for x86).
